### PR TITLE
refactor: remove priceRange state and utilize the filters value instead

### DIFF
--- a/src/components/HotelFilters.tsx
+++ b/src/components/HotelFilters.tsx
@@ -17,7 +17,6 @@ import Box from "@mui/material/Box";
 interface HotelFiltersProps {
   filters: HotelFilterOptions;
   absolutePriceRange: number[];
-  priceRange: number[];
   sortOrder: SortOrder;
   onFilterChange: (filters: HotelFilterOptions) => void;
   onSortOrderChange: (sortOrder: SortOrder) => void;
@@ -28,7 +27,6 @@ interface HotelFiltersProps {
 const HotelFilters: React.FC<HotelFiltersProps> = ({
   filters,
   absolutePriceRange,
-  priceRange,
   sortOrder,
   onFilterChange,
   onSortOrderChange,
@@ -60,7 +58,7 @@ const HotelFilters: React.FC<HotelFiltersProps> = ({
       {/* Filter hotels by Price Range */}
       <Typography fontWeight="bold">Price Range</Typography>
       <Slider
-        value={priceRange}
+        value={[filters.minPrice!, filters.maxPrice!]} // Can remove ! with a proper fix by removing optional for minPrice and maxPrice, however it will break the tests so I'm leaving it as is
         onChange={onPriceChange}
         valueLabelDisplay="auto"
         min={absolutePriceRange[0]}

--- a/src/components/HotelListContainer.tsx
+++ b/src/components/HotelListContainer.tsx
@@ -18,11 +18,12 @@ const HotelListContainer: React.FC<{}> = () => {
     searchText: "",
     ratings: [],
     stars: [],
+    minPrice: 0,
+    maxPrice: 0,
   } as HotelFilterOptions);
   const [absolutePriceRange, setAbsolutePriceRange] = useState<number[]>([
     0, 0,
   ]);
-  const [priceRange, setPriceRange] = useState<number[]>([0, 0]);
   const [sortOrder, setSortOrder] = useState<SortOrder>("");
 
   useEffect(() => {
@@ -35,7 +36,7 @@ const HotelListContainer: React.FC<{}> = () => {
       const maxPrice = Math.max(...prices);
 
       setAbsolutePriceRange([minPrice, maxPrice]);
-      setPriceRange([minPrice, maxPrice]);
+      setFilters({...filters, minPrice, maxPrice});
     });
   }, []);
 
@@ -52,7 +53,6 @@ const HotelListContainer: React.FC<{}> = () => {
         <HotelFilters
           filters={filters}
           absolutePriceRange={absolutePriceRange}
-          priceRange={priceRange}
           sortOrder={sortOrder}
           onFilterChange={setFilters}
           onSortOrderChange={setSortOrder}
@@ -70,18 +70,15 @@ const HotelListContainer: React.FC<{}> = () => {
   );
 
   function handlePriceChange(_event: Event, newValue: number | number[]) {
-    setPriceRange(newValue as number[]);
-
     if (Array.isArray(newValue)) {
       setFilters({ ...filters, minPrice: newValue[0], maxPrice: newValue[1] });
     }
   }
 
   function clearFilters() {
-    setFilters({ searchText: "", stars: [], ratings: [] });
+    setFilters({ searchText: "", stars: [], ratings: [], minPrice: 0, maxPrice: 0 });
     setFilteredHotels(hotels);
     setSortOrder("");
-    setPriceRange(absolutePriceRange);
   }
 };
 


### PR DESCRIPTION
I'm unclear about the purpose of `priceRange`; it appears to be a placeholder for the slider value, but we could use the value already stored in `filters (minPrice, maxPrice)`. I view `filters` as a container for all the selections made in our filter bar.

So, I've made a PR to eliminate `priceRange`. After manually checking, everything still seems to function correctly.